### PR TITLE
fix(gcpkms): verify ciphertext_crc32c and AAD_crc32c on Decrypt response

### DIFF
--- a/src/main/java/com/google/crypto/tink/integration/gcpkms/GcpKmsAead.java
+++ b/src/main/java/com/google/crypto/tink/integration/gcpkms/GcpKmsAead.java
@@ -123,6 +123,19 @@ public final class GcpKmsAead implements Aead {
               .decrypt(this.keyName, request)
               .execute();
 
+      // Verify the server confirmed it received the request CRCs intact;
+      // see https://cloud.google.com/kms/docs/data-integrity-guidelines.
+      if (response.getVerifiedCiphertextCrc32c() == null
+          || !response.getVerifiedCiphertextCrc32c()) {
+        throw new GeneralSecurityException(
+            "Verifying the provided ciphertext checksum failed.");
+      }
+      if (response.getVerifiedAdditionalAuthenticatedDataCrc32c() == null
+          || !response.getVerifiedAdditionalAuthenticatedDataCrc32c()) {
+        throw new GeneralSecurityException(
+            "Verifying the provided associated data checksum failed.");
+      }
+
       byte[] plaintext = toNonNullableByteArray(response.decodePlaintext());
       long plaintextCrc32c = Hashing.crc32c().hashBytes(plaintext).padToLong();
       if (response.getPlaintextCrc32c() != plaintextCrc32c) {
@@ -247,6 +260,17 @@ public final class GcpKmsAead implements Aead {
                 .build();
 
         com.google.cloud.kms.v1.DecryptResponse decResponse = kmsClient.decrypt(decryptRequest);
+
+        // Verify the server confirmed it received the request CRCs intact;
+        // see https://cloud.google.com/kms/docs/data-integrity-guidelines.
+        if (!decResponse.getVerifiedCiphertextCrc32C()) {
+          throw new GeneralSecurityException(
+              "Verifying the provided ciphertext checksum failed.");
+        }
+        if (!decResponse.getVerifiedAdditionalAuthenticatedDataCrc32C()) {
+          throw new GeneralSecurityException(
+              "Verifying the provided associated data checksum failed.");
+        }
 
         byte[] plaintext = decResponse.getPlaintext().toByteArray();
 


### PR DESCRIPTION
## Background

The two GcpKmsAead variants in `GcpKmsAead.java` (REST `GcpKmsAead` at lines 106-135 and gRPC `GcpKmsAeadGrpc` at lines 234-262) both set request-side CRC32C checksums on `decrypt`, but neither checks the response's `verified_ciphertext_crc32c` or `verified_additional_authenticated_data_crc32c` flags. The `Encrypt` paths in both variants already perform these checks.

Per the [Cloud KMS Data Integrity Guidelines](https://cloud.google.com/kms/docs/data-integrity-guidelines), the response must be rejected if the server did not confirm receipt of the request CRCs.

## Change

`Decrypt` now fails closed on:

- `!response.getVerifiedCiphertextCrc32c()`
- `!response.getVerifiedAdditionalAuthenticatedDataCrc32c()`

in both the REST variant (using boxed `Boolean` getters with null-check) and the gRPC variant (using primitive `boolean` getters), matching the existing Encrypt-side patterns in the same file.

## Sibling fixes

- [tink-go-gcpkms#21](https://github.com/tink-crypto/tink-go-gcpkms/pull/21)
- [tink-cc-gcpkms#2](https://github.com/tink-crypto/tink-cc-gcpkms/pull/2) (Decrypt)
- [tink-cc-gcpkms#3](https://github.com/tink-crypto/tink-cc-gcpkms/pull/3) (Encrypt)
- tink-py PR #77 (Python had no CRC32C at all on either direction)

All five PRs converge on the same Cloud KMS Data Integrity Guidelines compliance.